### PR TITLE
Add PyPI downloads badge to README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # OlsCheck
 
+[![PyPI Downloads](https://static.pepy.tech/personalized-badge/olscheck?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/olscheck)
+
 `olscheck` is a Python library designed to check and visualize the assumptions of Ordinary Least Squares (OLS). This tool streamlines the process of model diagnostics, offering an all-in-one solution for analyzing residuals, leverage, and multi-collinearity.
 
 ![Residuals vs Fitted](images/example_plot.png) 


### PR DESCRIPTION
### Motivation
- Add a PyPI downloads badge to the top of the project README so visitors can quickly see total downloads and project activity.

### Description
- Inserted the PyPI personalized badge markdown into `readme.md` immediately below the `# OlsCheck` header.

### Testing
- No automated tests were run because this is a documentation-only change; the test suite (`pytest`) was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973eb6dc68c8327a8016da9ce0f9d5f)