### PR TITLE
Add replenishment simulation scaffold with historical-error safety stock policy

### DIFF
--- a/janrth/__init__.py
+++ b/janrth/__init__.py
@@ -1,0 +1,1 @@
+"""Janrth workspace packages."""

--- a/janrth/replenishment_sim/__init__.py
+++ b/janrth/replenishment_sim/__init__.py
@@ -1,0 +1,10 @@
+"""Replenishment simulation library."""
+
+from .policies import HistoricalErrorSafetyStockPolicy
+from .simulation import ReplenishmentSimulation, SimulationConfig
+
+__all__ = [
+    "HistoricalErrorSafetyStockPolicy",
+    "ReplenishmentSimulation",
+    "SimulationConfig",
+]

--- a/janrth/replenishment_sim/policies.py
+++ b/janrth/replenishment_sim/policies.py
@@ -1,0 +1,22 @@
+"""Policy implementations for replenishment decisions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import pstdev
+
+
+@dataclass
+class HistoricalErrorSafetyStockPolicy:
+    """Safety stock based on historical forecast errors.
+
+    safety_stock = safety_factor * stddev(error_history)
+    """
+
+    safety_factor: float = 1.0
+    minimum_samples: int = 3
+
+    def safety_stock(self, error_history: list[float]) -> float:
+        if len(error_history) < self.minimum_samples:
+            return 0.0
+        return self.safety_factor * pstdev(error_history)

--- a/janrth/replenishment_sim/replenishment_simulation.ipynb
+++ b/janrth/replenishment_sim/replenishment_simulation.ipynb
@@ -1,0 +1,49 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Replenishment Simulation Demo\n",
+        "\n",
+        "This notebook shows how to run the replenishment simulation with a historical-error safety stock policy."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from janrth.replenishment_sim import HistoricalErrorSafetyStockPolicy, ReplenishmentSimulation, SimulationConfig\n",
+        "\n",
+        "demand = [12, 9, 11, 10, 13, 8, 9, 12, 10, 11]\n",
+        "config = SimulationConfig(\n",
+        "    initial_stock=20,\n",
+        "    lead_time_days=2,\n",
+        "    time_step_days=1,\n",
+        "    holding_cost_per_unit_per_day=0.1,\n",
+        "    stockout_cost_per_unit_per_day=1.0,\n",
+        "    forecast_window=3,\n",
+        ")\n",
+        "policy = HistoricalErrorSafetyStockPolicy(safety_factor=1.5)\n",
+        "simulation = ReplenishmentSimulation(config=config, policy=policy)\n",
+        "results = simulation.run(demand)\n",
+        "results[:5]"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.x"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/janrth/replenishment_sim/simulation.py
+++ b/janrth/replenishment_sim/simulation.py
@@ -1,0 +1,112 @@
+"""Core replenishment simulation logic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from .policies import HistoricalErrorSafetyStockPolicy
+
+
+@dataclass
+class SimulationConfig:
+    """Configuration for the replenishment simulation."""
+
+    initial_stock: float = 0.0
+    lead_time_days: int = 1
+    time_step_days: int = 1
+    holding_cost_per_unit_per_day: float = 0.0
+    stockout_cost_per_unit_per_day: float = 0.0
+    order_up_to_multiplier: float = 1.0
+    forecast_window: int = 5
+
+
+class ReplenishmentSimulation:
+    """Runs an inventory replenishment simulation over a demand series."""
+
+    def __init__(
+        self,
+        config: SimulationConfig,
+        policy: HistoricalErrorSafetyStockPolicy | None = None,
+    ) -> None:
+        self.config = config
+        self.policy = policy or HistoricalErrorSafetyStockPolicy()
+        self._validate_config()
+
+    def _validate_config(self) -> None:
+        if self.config.time_step_days <= 0:
+            raise ValueError("time_step_days must be positive")
+        if self.config.lead_time_days <= 0:
+            raise ValueError("lead_time_days must be positive")
+        if self.config.lead_time_days % self.config.time_step_days != 0:
+            raise ValueError("lead_time_days must be divisible by time_step_days")
+        if self.config.forecast_window <= 0:
+            raise ValueError("forecast_window must be positive")
+
+    def run(self, demand: Iterable[float]) -> list[dict[str, float]]:
+        """Run the simulation.
+
+        Args:
+            demand: Iterable of demand per time step.
+
+        Returns:
+            List of dicts with simulation state per step.
+        """
+
+        demand_series = list(demand)
+        lead_time_steps = self.config.lead_time_days // self.config.time_step_days
+        on_hand = float(self.config.initial_stock)
+        backlog = 0.0
+        pipeline: list[tuple[int, float]] = []
+        error_history: list[float] = []
+        results: list[dict[str, float]] = []
+
+        for step, actual_demand in enumerate(demand_series):
+            arrivals = [qty for arrival_step, qty in pipeline if arrival_step == step]
+            if arrivals:
+                on_hand += sum(arrivals)
+            pipeline = [item for item in pipeline if item[0] > step]
+
+            forecast = self._forecast(demand_series[:step])
+            if step > 0:
+                error_history.append(demand_series[step - 1] - self._forecast(demand_series[: step - 1]))
+
+            safety_stock = self.policy.safety_stock(error_history)
+            forecast_lead_time = forecast * lead_time_steps
+            order_up_to = (forecast_lead_time + safety_stock) * self.config.order_up_to_multiplier
+            inventory_position = on_hand + sum(qty for _, qty in pipeline) - backlog
+
+            order_qty = max(order_up_to - inventory_position, 0.0)
+            if order_qty > 0:
+                arrival_step = step + lead_time_steps
+                pipeline.append((arrival_step, order_qty))
+
+            demand_fulfilled = min(on_hand, actual_demand)
+            on_hand -= demand_fulfilled
+            backlog = max(actual_demand - demand_fulfilled, 0.0)
+
+            holding_cost = on_hand * self.config.holding_cost_per_unit_per_day * self.config.time_step_days
+            stockout_cost = backlog * self.config.stockout_cost_per_unit_per_day * self.config.time_step_days
+
+            results.append(
+                {
+                    "step": float(step),
+                    "demand": float(actual_demand),
+                    "forecast": float(forecast),
+                    "safety_stock": float(safety_stock),
+                    "order_qty": float(order_qty),
+                    "on_hand": float(on_hand),
+                    "backlog": float(backlog),
+                    "holding_cost": float(holding_cost),
+                    "stockout_cost": float(stockout_cost),
+                    "total_cost": float(holding_cost + stockout_cost),
+                }
+            )
+
+        return results
+
+    def _forecast(self, history: list[float]) -> float:
+        if not history:
+            return 0.0
+        window = history[-self.config.forecast_window :]
+        return sum(window) / len(window)


### PR DESCRIPTION
### Motivation
- Provide a new local library to simulate and compare inventory replenishment policies and their cost outcomes.
- Start with a simple, parameterizable simulation that accepts demand, lead time, time granularity, holding costs and stockout costs.
- Implement a baseline safety-stock policy computed from historical forecast errors to serve as a first policy to evaluate.

### Description
- Add a new package `janrth.replenishment_sim` with `__init__.py`, a policy module `policies.py`, a simulation core `simulation.py`, and a demo notebook `replenishment_simulation.ipynb`.
- Implement `HistoricalErrorSafetyStockPolicy` which computes safety stock as `safety_factor * pstdev(error_history)` with a configurable `minimum_samples` and `safety_factor` in `policies.py`.
- Add `SimulationConfig` dataclass and `ReplenishmentSimulation` class in `simulation.py` that validate config, run a stepwise simulation with a pipeline for lead-time arrivals, compute moving-average `forecast` over `forecast_window`, track `on_hand` and `backlog`, place orders to an `order_up_to` level, and compute `holding_cost`, `stockout_cost`, and `total_cost` per step.
- Provide a notebook showing a runnable example that imports `HistoricalErrorSafetyStockPolicy`, `SimulationConfig`, and `ReplenishmentSimulation` and prints the first results.

### Testing
- No automated tests were run as part of this change (demo and scaffolding only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69754482bec08327a990f56869737639)